### PR TITLE
Add options to pass 'timestamp' and 'category' labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Use it with a scheduled Github actions workflow.
 Inputs:
 
 * `report-file` - Name of the file with a reported created by Snyk.
+* `timestamp` - The timestamp of the Snyk run. All Snyk runs with the same timestamp will be treated as a single search i.e. only vulnerabilities not detected across all runs with the same timestamp will be removed.
+* `category` - Optional 'Snyk-category' label added to the Issue.
 
 Environment variables:
 
@@ -42,6 +44,8 @@ jobs:
       uses: thehyve/report-vulnerability@master
       with:
         report-file: ${{ env.REPORT_FILE }}
+        timestamp: 2025-01-01T00:00:00Z
+        category: 'radarbase/radar-home:latest
       env:
         TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ failure() }}

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,20 @@ inputs:
     description: "The report's file path"
     required: true
     default: "test.json"
+  timestamp:
+    description: "The timestamp of the Snyk run. All Snyk runs with the same timestamp will be treated as a single search i.e. only vulnerabilities not detected across all runs with the same timestamp will be removed."
+    required: false
+    default: ${{ github.run_id }}
+  category:
+    description: "Optional 'Snyk-category' label added to the Issue."
+    required: false
+    default: all
 runs:
   using: 'docker'
-  image: 'docker://quay.io/thehyve/report-vulnerability:latest'
+  image: 'docker://docker.io/pvannierop/report-vulnerability:latest'
   args:
   - ${{ inputs.report-file }}
+  - --timestamp
+  - ${{ inputs.timestamp }}
+  - --category
+  - ${{ inputs.category }}


### PR DESCRIPTION
The following job params were added:

* `timestamp` - The timestamp of the Snyk run. All Snyk runs with the same timestamp will be treated as a single search i.e. only vulnerabilities not detected across all runs with the same timestamp will be removed.
* `category` - Optional 'Snyk-category' label added to the Issue.

